### PR TITLE
Try using octodns-cloudflare custom action

### DIFF
--- a/.github/actions/octodns-cloudflare/Dockerfile
+++ b/.github/actions/octodns-cloudflare/Dockerfile
@@ -1,1 +1,1 @@
-FROM octodns/cloudflare:2023.02
+FROM octodns/cloudflare:2022.12

--- a/.github/actions/octodns-cloudflare/Dockerfile
+++ b/.github/actions/octodns-cloudflare/Dockerfile
@@ -1,0 +1,1 @@
+FROM octodns/cloudflare:2023.02

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,11 @@ updates:
   reviewers:
     - parkr
   open-pull-requests-limit: 99
-  
+- package-ecosystem: docker
+  directory: /.github/actions/octodns-cloudflare
+  schedule:
+    interval: daily
+    time: "11:00"
+  reviewers:
+    - parkr
+  open-pull-requests-limit: 99

--- a/.github/workflows/push-deploy-on-push.yml
+++ b/.github/workflows/push-deploy-on-push.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: octodns sync
-      uses: docker://octodns/cloudflare:2022.12
+      uses: ./.github/actions/octodns-cloudflare
       env:
         CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
         CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}

--- a/.github/workflows/push-test-on-push.yml
+++ b/.github/workflows/push-test-on-push.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: octodns test
-      uses: docker://octodns/cloudflare:2022.12
+      uses: ./.github/actions/octodns-cloudflare
       env:
         CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
         CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}


### PR DESCRIPTION
By using a custom Action, we can get Dependabot to upgrade the octodns version for us (it doesn't support the docker:// syntax in workflows 😭 )